### PR TITLE
[gato] Fix N_cost not being used. 

### DIFF
--- a/gato/dynamics/iiwa14/iiwa14_plant.cuh
+++ b/gato/dynamics/iiwa14/iiwa14_plant.cuh
@@ -445,8 +445,9 @@ namespace plant {
                                                                  T        ctrl_lim_cost)
         {
                 trackingCostGradientAndHessian<T>(state_size, control_size, s_xux, s_eePos_traj, s_Qk, s_qk, s_Rk, s_rk, s_temp, d_dynMem_const, q_cost, qd_cost, u_cost, N_cost, q_lim_cost, vel_lim_cost, ctrl_lim_cost);
+                T* s_xkp1 = s_xux + state_size + control_size;
                 trackingCostGradientAndHessian<T, false>(
-                    state_size, control_size, s_xux, &s_eePos_traj[6], s_Qkp1, s_qkp1, nullptr, nullptr, s_temp, d_dynMem_const, q_cost, qd_cost, u_cost, N_cost, q_lim_cost, vel_lim_cost, ctrl_lim_cost);
+                    state_size, control_size, s_xkp1, &s_eePos_traj[6], s_Qkp1, s_qkp1, nullptr, nullptr, s_temp, d_dynMem_const, N_cost, qd_cost, u_cost, N_cost, q_lim_cost, vel_lim_cost, ctrl_lim_cost);
         }
 
         __host__ __device__ constexpr unsigned trackingCostGradientAndHessian_TempMemSize_Shared()

--- a/gato/dynamics/indy7/indy7_plant.cuh
+++ b/gato/dynamics/indy7/indy7_plant.cuh
@@ -442,8 +442,9 @@ namespace plant {
                                                                  T        ctrl_lim_cost)
         {
                 trackingCostGradientAndHessian<T>(state_size, control_size, s_xux, s_eePos_traj, s_Qk, s_qk, s_Rk, s_rk, s_temp, d_dynMem_const, q_cost, qd_cost, u_cost, N_cost, q_lim_cost, vel_lim_cost, ctrl_lim_cost);
+                T* s_xkp1 = s_xux + state_size + control_size;
                 trackingCostGradientAndHessian<T, false>(
-                    state_size, control_size, s_xux, &s_eePos_traj[6], s_Qkp1, s_qkp1, nullptr, nullptr, s_temp, d_dynMem_const, q_cost, qd_cost, u_cost, N_cost, q_lim_cost, vel_lim_cost, ctrl_lim_cost);
+                    state_size, control_size, s_xkp1, &s_eePos_traj[6], s_Qkp1, s_qkp1, nullptr, nullptr, s_temp, d_dynMem_const, N_cost, qd_cost, u_cost, N_cost, q_lim_cost, vel_lim_cost, ctrl_lim_cost);
         }
 
         __host__ __device__ constexpr unsigned trackingCostGradientAndHessian_TempMemSize_Shared()


### PR DESCRIPTION
Use the terminal state `x_{k+1}` when building the final state cost block, and apply `N_cost`
  as the terminal position tracking weight there.

  Before this fix, a tracking example showed no response to changes in `N_cost` because the terminal KKT block used the previous state and the running tracking weight (`q_cost`). The change is in  `__device__ void trackingCostGradientAndHessian_lastblock` in both `indy7_plant.cuh` and `iiwa14_plant.cuh`, where the final block now uses the correct terminal state block and `N_cost`.

Before fix no reaction to `N_cost`:

<img width="1280" height="800" alt="terminal_weight_probe_terminal_distance" src="https://github.com/user-attachments/assets/2e1c23c7-287f-4f70-94df-03099045af7b" />

After the fix:

<img width="1280" height="800" alt="fixed_terminal_weight_probe_terminal_distance" src="https://github.com/user-attachments/assets/fc89a338-a3ec-4fd5-8d93-8ad3dd9daa45" />

<img width="1920" height="1440" alt="fixed_terminal_weight_probe" src="https://github.com/user-attachments/assets/6083cfe5-8575-4992-9345-199957729578" />

@cherti

This bug was found by an agent but audited by myself. I also validated that the bugfix does not negatively impact any other tasks. 